### PR TITLE
allow the ngs tool to reference the current nsc

### DIFF
--- a/install.py
+++ b/install.py
@@ -43,8 +43,8 @@ NGS_FILENAME_LOOKUP = {
 
 
 NSC_REPO_URL = "https://github.com/nats-io/nsc"
-# NSC_LATEST_RELEASE_URL = NSC_REPO_URL + "/releases/latest"
-NSC_PROD_RELEASE_URL = NSC_REPO_URL + "/releases/tag/0.5.0"
+NSC_LATEST_RELEASE_URL = NSC_REPO_URL + "/releases/latest"
+# NSC_PROD_RELEASE_URL = NSC_REPO_URL + "/releases/tag/0.5.0"
 NSC_TAG_URL = NSC_REPO_URL + "/releases/tag/"
 NSC_FILENAME_LOOKUP = {
     "darwin": "nsc-darwin-amd64.zip",

--- a/install.sh
+++ b/install.sh
@@ -110,7 +110,7 @@ main() {
     "$NGS_BINARY_BASENAME" "$PURPOSE_NGS"
 }
 
-opt_tag_nsc="$NSC_PROD_COMPAT_RELEASE"
+opt_tag_nsc=''
 opt_tag_ngs=''
 opt_install_dir=''
 opt_symlink_dir=''


### PR DESCRIPTION
This should allow the entire tooling to work top of the world. Note that we have not published the 0.20.0 release for the ngs tool so we shouldn't merge until that happens.